### PR TITLE
command/token-lookup: new cmdline switch -token-accessor

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -25,11 +25,12 @@ import (
 
 // BaseCommand is a Command that holds the common command options
 type BaseCommand struct {
-	Address      string
-	OutputFormat string
-	Token        string
-	UI           cli.Ui
-	client       *api.Client
+	Address       string
+	OutputFormat  string
+	Token         string
+	TokenAccessor string
+	UI            cli.Ui
+	client        *api.Client
 }
 
 // Client returs a new HTTP API Vault client for the given configuration

--- a/command/main.go
+++ b/command/main.go
@@ -36,6 +36,9 @@ const (
 	tokenDescr   = "The token to access Vault. " +
 		"Overrides the " + api.EnvVaultToken + " environment variable if set"
 
+	tokenAccessorDefault = ""
+	tokenAccessorDescr   = "The token accessor to lookup"
+
 	warningDescr  = "Warning threshold (default: %s)"
 	criticalDescr = "Critical threshold (default: %s)"
 

--- a/command/main_test.go
+++ b/command/main_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/hashicorp/vault/builtin/logical/pki"
 	"github.com/hashicorp/vault/builtin/logical/ssh"
 	"github.com/hashicorp/vault/builtin/logical/transit"
-	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 
 	auditFile "github.com/hashicorp/vault/builtin/audit/file"


### PR DESCRIPTION
Add the command-line switch `-token-accessor` to the command `token-lookup` to check the expiration token time throughout its associated token accessor.

Feature asked by `unix196` (https://github.com/unix196).

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>