### PR TITLE
Send all the messages to stdout in Nagios compliant mode

### DIFF
--- a/command/main.go
+++ b/command/main.go
@@ -66,6 +66,7 @@ func Run(args []string) int {
 					UI: &cli.ColoredUi{
 						Ui:          ui,
 						ErrorColor:  cli.UiColorRed,
+						InfoColor:   cli.UiColorNone,
 						OutputColor: cli.UiColorGreen,
 						WarnColor:   cli.UiColorYellow,
 					},
@@ -79,6 +80,7 @@ func Run(args []string) int {
 					UI: &cli.ColoredUi{
 						Ui:          ui,
 						ErrorColor:  cli.UiColorRed,
+						InfoColor:   cli.UiColorNone,
 						OutputColor: cli.UiColorGreen,
 						WarnColor:   cli.UiColorYellow,
 					},
@@ -92,6 +94,7 @@ func Run(args []string) int {
 					UI: &cli.ColoredUi{
 						Ui:          ui,
 						ErrorColor:  cli.UiColorRed,
+						InfoColor:   cli.UiColorNone,
 						OutputColor: cli.UiColorGreen,
 						WarnColor:   cli.UiColorYellow,
 					},
@@ -105,6 +108,7 @@ func Run(args []string) int {
 					UI: &cli.ColoredUi{
 						Ui:          ui,
 						ErrorColor:  cli.UiColorRed,
+						InfoColor:   cli.UiColorNone,
 						OutputColor: cli.UiColorGreen,
 						WarnColor:   cli.UiColorYellow,
 					},
@@ -118,6 +122,7 @@ func Run(args []string) int {
 					UI: &cli.ColoredUi{
 						Ui:          ui,
 						ErrorColor:  cli.UiColorRed,
+						InfoColor:   cli.UiColorNone,
 						OutputColor: cli.UiColorGreen,
 						WarnColor:   cli.UiColorYellow,
 					},

--- a/command/output.go
+++ b/command/output.go
@@ -62,13 +62,13 @@ func (c *BaseCommand) OutputHandle() (*Outputter, error) {
 				c.UI.Output(fmt.Sprintf("vault OK - "+format, a...))
 			},
 			Warning: func(format string, a ...interface{}) {
-				c.UI.Warn(fmt.Sprintf("vault WARNING - "+format, a...))
+				c.UI.Output(fmt.Sprintf("vault WARNING - "+format, a...))
 			},
 			Critical: func(format string, a ...interface{}) {
-				c.UI.Error(fmt.Sprintf("vault CRITICAL - "+format, a...))
+				c.UI.Output(fmt.Sprintf("vault CRITICAL - "+format, a...))
 			},
 			Undefined: func(format string, a ...interface{}) {
-				c.UI.Error(fmt.Sprintf("vault UNDEFINED - "+format, a...))
+				c.UI.Output(fmt.Sprintf("vault UNDEFINED - "+format, a...))
 			},
 		}, nil
 	default:

--- a/command/output.go
+++ b/command/output.go
@@ -59,16 +59,16 @@ func (c *BaseCommand) OutputHandle() (*Outputter, error) {
 	case "nagios":
 		return &Outputter{
 			Output: func(format string, a ...interface{}) {
-				c.UI.Output(fmt.Sprintf("vault OK - "+format, a...))
+				c.UI.Info(fmt.Sprintf("vault OK - "+format, a...))
 			},
 			Warning: func(format string, a ...interface{}) {
-				c.UI.Output(fmt.Sprintf("vault WARNING - "+format, a...))
+				c.UI.Info(fmt.Sprintf("vault WARNING - "+format, a...))
 			},
 			Critical: func(format string, a ...interface{}) {
-				c.UI.Output(fmt.Sprintf("vault CRITICAL - "+format, a...))
+				c.UI.Info(fmt.Sprintf("vault CRITICAL - "+format, a...))
 			},
 			Undefined: func(format string, a ...interface{}) {
-				c.UI.Output(fmt.Sprintf("vault UNDEFINED - "+format, a...))
+				c.UI.Info(fmt.Sprintf("vault UNDEFINED - "+format, a...))
 			},
 		}, nil
 	default:


### PR DESCRIPTION
This is required because, as pointed out by unix196, Nagios shows
an empty output in case of warning and error messages.

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>